### PR TITLE
Added Request Dispatcher Layer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     window: true,
     hepsiBus: true,
     global: true,
-    jest: true,
+    jest: true
   },
   parserOptions: {
     ecmaFeatures: {
@@ -46,7 +46,13 @@ module.exports = {
     'no-nested-ternary': 'off',
     'no-underscore-dangle': 'off',
     'consistent-return': 'off',
-    'array-callback-return': 'off'
+    'array-callback-return': 'off',
+    'no-restricted-syntax': [
+      'error',
+      'FunctionExpression',
+      'WithStatement',
+      "BinaryExpression[operator='in']"
+    ]
   },
   env: {
     jest: true,

--- a/config/string.js
+++ b/config/string.js
@@ -7,12 +7,18 @@ const voltranConfig = require('../voltran.config');
 
 const prometheusFile = voltranConfig.monitoring.prometheus;
 
-function replaceString () {
-	const data = [
-		{ search: '__V_COMPONENTS__', replace: normalizeUrl(voltranConfig.routing.components), flags: 'g' },
+function replaceString() {
+  const data = [
+    {
+      search: '__V_COMPONENTS__',
+      replace: normalizeUrl(voltranConfig.routing.components),
+      flags: 'g'
+    },
     {
       search: '__APP_CONFIG__',
-      replace: normalizeUrl(`${voltranConfig.appConfigFile.output.path}/${voltranConfig.appConfigFile.output.name}.js`),
+      replace: normalizeUrl(
+        `${voltranConfig.appConfigFile.output.path}/${voltranConfig.appConfigFile.output.name}.js`
+      ),
       flags: 'g'
     },
     {
@@ -20,14 +26,31 @@ function replaceString () {
       replace: normalizeUrl(`${voltranConfig.inputFolder}/assets.json`),
       flags: 'g'
     },
-    { search: '__V_DICTIONARY__', replace: normalizeUrl(voltranConfig.routing.dictionary), flags: 'g' },
-    { search: '@voltran/core', replace: normalizeUrl(path.resolve(__dirname, '../src/index')), flags: 'g' },
+    {
+      search: '__V_DICTIONARY__',
+      replace: normalizeUrl(voltranConfig.routing.dictionary),
+      flags: 'g'
+    },
+    {
+      search: '__V_REQUEST_CONFIGS__',
+      replace: normalizeUrl(voltranConfig.routing.requestConfigs),
+      flags: 'g'
+    },
+    {
+      search: '@voltran/core',
+      replace: normalizeUrl(path.resolve(__dirname, '../src/index')),
+      flags: 'g'
+    },
     { search: '"__V_styles__"', replace: getStyles() }
   ];
 
-  data.push({ search: '__V_PROMETHEUS__', replace: normalizeUrl(prometheusFile ? prometheusFile : '../lib/tools/prom.js'), flags: 'g' });
+  data.push({
+    search: '__V_PROMETHEUS__',
+    replace: normalizeUrl(prometheusFile ? prometheusFile : '../lib/tools/prom.js'),
+    flags: 'g'
+  });
 
-	return data;
+  return data;
 }
 
 module.exports = replaceString;

--- a/package.json
+++ b/package.json
@@ -132,5 +132,9 @@
     "commitLimit": false,
     "template": "changelog-template.hbs",
     "package": true
+  },
+  "peerDependencies": {
+    "react": ">=16.13.0",
+    "react-dom": ">=16.13.0"
   }
 }

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -1,15 +1,10 @@
 import 'whatwg-fetch';
 import Eev from 'eev';
 
-const appConfig = require('__APP_CONFIG__');
-
-const defaultEventBusName = 'eventBus';
 /* eslint-disable-next-line */
-('__V_styles__');
+"__V_styles__"
 
 if (!window.HbEventBus) {
-  const name = appConfig.eventBusName || defaultEventBusName;
-
-  window[name] = new Eev();
+  window.HbEventBus = new Eev();
   window.voltran_project_version = process.env.APP_BUILD_VERSION || '1.0.0';
 }

--- a/src/render.js
+++ b/src/render.js
@@ -16,8 +16,7 @@ import logger from './universal/utils/logger';
 
 const appConfig = require('__APP_CONFIG__');
 
-// eslint-disable-next-line consistent-return
-export default async (req, res) => {
+const render = async (req, res) => {
   const isWithoutStateValue = isWithoutState(req.query);
   const pathParts = xss(req.path)
     .split('/')
@@ -63,7 +62,7 @@ export default async (req, res) => {
       componentName,
       seoState,
       isPreviewQuery,
-      responseOptions,
+      responseOptions
     } = renderResponse;
 
     const statusCode = responseOptions?.isPartialContent
@@ -84,7 +83,9 @@ export default async (req, res) => {
       if (voltranEnv !== 'prod' && isPreviewQuery) {
         res.status(statusCode).html(Preview([fullHtml].join('\n')));
       } else {
-        res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR).html('<h1>Aradığınız sayfa bulunamadı...</h1>');
+        res
+          .status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR)
+          .html('<h1>Aradığınız sayfa bulunamadı...</h1>');
       }
     }
   } else {
@@ -93,3 +94,5 @@ export default async (req, res) => {
     });
   }
 };
+
+export default render;

--- a/src/universal/components/Preview.js
+++ b/src/universal/components/Preview.js
@@ -13,7 +13,10 @@ export default (body, title = null) => {
         <title>Preview${additionalTitle}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <script>window.HBUS_LAZY = true;</script>
-        <script src="${appConfig.voltranCommonUrl}"></script>
+
+        ${cr(
+          appConfig.voltranCommonUrl ? `<script src="${appConfig.voltranCommonUrl}"></script>` : ''
+        )}
         ${cr(
           appConfig.showPreviewFrame,
           `<style>
@@ -31,7 +34,7 @@ export default (body, title = null) => {
               -moz-osx-font-smoothing: grayscale;
             }
 
-            
+
             .voltran-body.full {
               width: auto;
               padding: 0;

--- a/src/universal/components/RequestDispatcher/RequestDispatcher.js
+++ b/src/universal/components/RequestDispatcher/RequestDispatcher.js
@@ -1,0 +1,63 @@
+import { useEffect } from 'react';
+
+import withBaseComponent from '../../partials/withBaseComponent';
+import { getEventBus } from '../../utils/helper';
+import { isExitCondition } from './RequestDispatcher.utils';
+
+const requestConfigs = require('__V_REQUEST_CONFIGS__');
+
+const { effects } = requestConfigs.default;
+const requestPrefix = 'RequestDispatcher.';
+const responsePrefix = 'RequestDispatcher.Response.';
+
+const RequestDispatcher = () => {
+  const fragment = '';
+
+  if (!process.env.BROWSER) {
+    return fragment;
+  }
+
+  window.HBUS_LAZY = true;
+
+  useEffect(() => {
+    const eventBus = getEventBus();
+
+    const broadcast = (effect, error, body) => {
+      effect.Subscribers.forEach(responseName => {
+        eventBus.emit(`${responsePrefix}${responseName}`, { error, body });
+      });
+    };
+
+    const runEffect = (effect, data) => {
+      effect
+        .Request(data)
+        .then(response => broadcast(effect, null, response))
+        .catch(error => broadcast(effect, error, null));
+    };
+
+    const requestHandler = requestName => {
+      return data => {
+        if (!Object.prototype.hasOwnProperty.call(effects, requestName)) {
+          return;
+        }
+
+        const conditions = effects[requestName];
+
+        for (const condition in conditions) {
+          if (isExitCondition(condition)) {
+            runEffect(conditions[condition], data);
+            break;
+          }
+        }
+      };
+    };
+
+    Object.keys(effects).forEach(requestName => {
+      eventBus.on(`${requestPrefix}${requestName}`, requestHandler(requestName));
+    });
+  }, []);
+
+  return fragment;
+};
+
+export default withBaseComponent(RequestDispatcher, '/RequestDispatcher');

--- a/src/universal/components/RequestDispatcher/RequestDispatcher.utils.js
+++ b/src/universal/components/RequestDispatcher/RequestDispatcher.utils.js
@@ -1,0 +1,12 @@
+import { getEventBus, getProjectWindowData } from '../../utils/helper';
+
+const isEventExist = eventName => {
+  const eventBus = getEventBus();
+  return eventBus && Object.keys(eventBus.events).indexOf(eventName) > -1;
+};
+
+const isExitCondition = condition => {
+  return Object.keys(getProjectWindowData()).indexOf(condition) > -1 || condition === 'default';
+};
+
+export { isExitCondition, isEventExist };

--- a/src/universal/components/RequestDispatcher/index.js
+++ b/src/universal/components/RequestDispatcher/index.js
@@ -1,0 +1,1 @@
+export { default } from './RequestDispatcher';

--- a/src/universal/core/route/components.js
+++ b/src/universal/core/route/components.js
@@ -1,0 +1,29 @@
+import { generateComponents } from '../../utils/helper';
+import RequestDispatcher from '../../components/RequestDispatcher';
+
+const componentConfig = require('__V_COMPONENTS__');
+
+const ROUTE_PATHS = {
+  REQUEST_DISPATCHER: '/RequestDispatcher'
+};
+const ROUTE_COMPONENTS = {
+  [ROUTE_PATHS.REQUEST_DISPATCHER]: RequestDispatcher
+};
+const defaultPartialsConfig = {
+  paths: ROUTE_PATHS,
+  components: ROUTE_COMPONENTS
+};
+
+const mergePartials = () => {
+  const { paths = {}, components = [], ...others } = componentConfig.default;
+
+  return {
+    paths: { ...paths, ...defaultPartialsConfig?.paths },
+    components: { ...components, ...defaultPartialsConfig?.components },
+    ...others
+  };
+};
+
+const components = generateComponents(mergePartials());
+
+export default components;

--- a/src/universal/core/route/dictionary.js
+++ b/src/universal/core/route/dictionary.js
@@ -1,0 +1,10 @@
+const path = require('path');
+
+const ROUTE_CONFIG_TO_COMPONENT_DICT = [
+  {
+    path: path.resolve(__dirname, '../../components/RequestDispatcher/RequestDispatcher'),
+    routePath: '/RequestDispatcher'
+  }
+];
+
+module.exports = ROUTE_CONFIG_TO_COMPONENT_DICT;

--- a/src/universal/core/route/routeConstants.js
+++ b/src/universal/core/route/routeConstants.js
@@ -1,9 +1,5 @@
 import values from 'lodash/values';
-import { generateComponents } from '../../utils/helper';
-
-const componentConfig = require('__V_COMPONENTS__');
-
-const components = generateComponents(componentConfig.default);
+import components from './components';
 
 const ROUTE_PATHS = {};
 const ROUTE_CONFIGS = {};

--- a/src/universal/core/route/routesWithComponents.js
+++ b/src/universal/core/route/routesWithComponents.js
@@ -1,8 +1,4 @@
-import { generateComponents } from '../../utils/helper';
-
-const componentConfig = require('__V_COMPONENTS__');
-
-const components = generateComponents(componentConfig.default);
+import components from './components';
 
 const routesWithComponents = {};
 

--- a/src/universal/model/Component.js
+++ b/src/universal/model/Component.js
@@ -1,10 +1,7 @@
 import routesWithComponents from '../core/route/routesWithComponents';
 // eslint-disable-next-line import/named
-import { createComponentName, generateComponents } from '../utils/helper';
-
-const componentConfig = require('__V_COMPONENTS__');
-
-const components = generateComponents(componentConfig.default);
+import { createComponentName } from '../utils/helper';
+import components from '../core/route/components';
 
 export default class Component {
   static getComponentName = path => {
@@ -13,16 +10,16 @@ export default class Component {
 
   static getComponentPath = name => `/${name}`;
 
-  static getComponentIsMobileFragment = path => {
-    return components[path].isMobileFragment ? components[path].isMobileFragment : false;
+  static getComponentIsMobileFragment = (path = '') => {
+    return components?.[path]?.isMobileFragment ?? false;
   };
 
-  static getComponentIsFullWidth = path => {
-    return components[path].fullWidth ? components[path].fullWidth : false;
+  static getComponentIsFullWidth = (path = '') => {
+    return components?.[path]?.fullWidth ?? false;
   };
 
-  static getComponentIsPreviewQuery = path => {
-    return components[path].isPreviewQuery || true;
+  static getComponentIsPreviewQuery = (path = '') => {
+    return components?.[path]?.isPreviewQuery ?? true;
   };
 
   static getComponentObjectWithPath = path => routesWithComponents[path];

--- a/src/universal/model/Renderer.js
+++ b/src/universal/model/Renderer.js
@@ -1,5 +1,5 @@
 import ServerApiManagerCache from '../core/api/ServerApiManagerCache';
-import { renderComponent, renderLinksAndScripts } from '../service/RenderService';
+import { isPreview, renderComponent, renderLinksAndScripts } from '../service/RenderService';
 
 export default class Renderer {
   constructor(component, context) {
@@ -9,8 +9,10 @@ export default class Renderer {
     this.initialState = null;
     this.winnerMap = null;
 
-    if (this.isPredefinedInitialStateSupported() &&
-      (process.env.BROWSER || (!process.env.BROWSER && !this.context.isWithoutState))) {
+    if (
+      this.isPredefinedInitialStateSupported() &&
+      (process.env.BROWSER || (!process.env.BROWSER && !this.context.isWithoutState))
+    ) {
       this.servicesMap = this.getServicesMap();
       this.winnerMap = {};
     }
@@ -38,12 +40,19 @@ export default class Renderer {
   render() {
     return new Promise(resolve => {
       renderComponent(this.component, this.context, this.initialState).then(response => {
-        const { output, links, scripts, activeComponent, seoState } = response;
+        const { output, links, scripts, activeComponent, seoState, fullHtml } = response;
         const html = renderLinksAndScripts(output, '', '');
 
         resolve({
           key: this.component.name,
-          value: { html, scripts, style: links, activeComponent, seoState },
+          value: {
+            html,
+            scripts,
+            style: links,
+            activeComponent,
+            seoState,
+            ...(isPreview(this.context?.query) && { fullHtml })
+          },
           id: this.component.id
         });
       });

--- a/src/universal/partials/Welcome/partials.js
+++ b/src/universal/partials/Welcome/partials.js
@@ -1,8 +1,4 @@
-import { generateComponents } from '../../utils/helper';
-
-const componentConfig = require('__V_COMPONENTS__');
-
-const components = generateComponents(componentConfig.default);
+import components from '../../core/route/components';
 
 const partials = [];
 

--- a/src/universal/service/RenderService.js
+++ b/src/universal/service/RenderService.js
@@ -19,12 +19,12 @@ const getStates = async (component, context, predefinedInitialState) => {
     return { initialState, seoState, subComponentFiles, responseOptions };
   }
 
-  if (!predefinedInitialState && component.getInitialState) {
+  if (!predefinedInitialState && component?.getInitialState) {
     const services = component.services.map(serviceName => ServerApiManagerCache[serviceName]);
     initialState.data = await component.getInitialState(...[...services, context]);
   }
 
-  if (component.getSeoState) {
+  if (component?.getSeoState) {
     seoState = component.getSeoState(initialState.data);
   }
 
@@ -90,6 +90,10 @@ const isWithoutState = query => {
   return query.withoutState === '';
 };
 
+const isRequestDispatcher = query => {
+  return query.requestDispathcer === '' || query.requestDispathcer !== 'false';
+};
+
 const renderComponent = async (component, context, predefinedInitialState = null) => {
   const { initialState, seoState, subComponentFiles, responseOptions } = await getStates(
     component.object,
@@ -116,8 +120,17 @@ const renderComponent = async (component, context, predefinedInitialState = null
     fullWidth: component.fullWidth,
     isMobileComponent: component.isMobileComponent,
     isPreviewQuery: component.isPreviewQuery,
-    responseOptions,
+    responseOptions
   };
 };
 
-export { renderHtml, renderLinksAndScripts, getStates, isWithoutHTML, isPreview, isWithoutState, renderComponent };
+export {
+  renderHtml,
+  renderLinksAndScripts,
+  getStates,
+  isWithoutHTML,
+  isPreview,
+  isRequestDispatcher,
+  isWithoutState,
+  renderComponent
+};

--- a/src/universal/utils/baseRenderHtml.js
+++ b/src/universal/utils/baseRenderHtml.js
@@ -29,30 +29,28 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 const getScripts = (name, subComponentFiles) => {
-  const subComponentFilesScripts = subComponentFiles.scripts;
+  const subComponentFilesScripts = subComponentFiles?.scripts;
   const scripts = [
     {
-      src: `${assetsBaseUrl}${assets.client.js}`,
+      src: `${assetsBaseUrl}${assets?.client?.js}`,
       isAsync: false
     },
     {
-      src: `${assetsBaseUrl}${assets[name].js}`,
+      src: `${assetsBaseUrl}${assets?.[name]?.js}`,
       isAsync: false
     }
   ];
   const mergedScripts =
-    subComponentFilesScripts && subComponentFilesScripts.length > 0
-      ? scripts.concat(subComponentFiles.scripts)
-      : scripts;
+    subComponentFilesScripts?.length > 0 ? scripts.concat(subComponentFiles.scripts) : scripts;
 
   return mergedScripts;
 };
 
 const getStyles = async (name, subComponentFiles) => {
   const links = [];
-  const subComponentFilesStyles = subComponentFiles.styles;
+  const subComponentFilesStyles = subComponentFiles?.styles;
 
-  if (assets[name].css) {
+  if (assets?.[name]?.css) {
     links.push({
       rel: 'stylesheet',
       href: `${assetsBaseUrl}${assets[name].css}`,
@@ -63,7 +61,7 @@ const getStyles = async (name, subComponentFiles) => {
     });
   }
 
-  if (assets.client.css) {
+  if (assets?.client?.css) {
     links.push({
       rel: 'stylesheet',
       href: `${assetsBaseUrl}${assets.client.css}`,
@@ -75,9 +73,7 @@ const getStyles = async (name, subComponentFiles) => {
   }
 
   const mergedLinks =
-    subComponentFilesStyles && subComponentFilesStyles.length > 0
-      ? links.concat(subComponentFiles.styles)
-      : links;
+    subComponentFilesStyles?.length > 0 ? links.concat(subComponentFiles.styles) : links;
 
   return mergedLinks;
 };

--- a/src/universal/utils/helper.js
+++ b/src/universal/utils/helper.js
@@ -1,4 +1,6 @@
 // eslint-disable-next-line import/prefer-default-export
+import voltranConfig from '../../../voltran.config';
+
 export const removeQueryStringFromUrl = url => {
   const partials = url.split('?');
 
@@ -20,12 +22,9 @@ const toCamel = (value = '') => {
     .toLowerCase();
 };
 
-export const generateComponents = ({
-  paths = {},
-  components = [],
-  defaultConfig = {},
-  customConfig = {}
-}) => {
+export const generateComponents = partialsConfig => {
+  const { paths = {}, components = [], defaultConfig = {}, customConfig = {} } = partialsConfig;
+
   let result = {};
   Object.entries(paths).forEach(([key, value]) => {
     result = {
@@ -46,6 +45,15 @@ export const generateComponents = ({
 export function guid() {
   return `${s4()}${s4()}-${s4()}-4${s4().substr(0, 3)}-${s4()}-${s4()}${s4()}${s4()}`.toLowerCase();
 }
+
+export const getEventBus = () => {
+  return process.env.BROWSER && window && window.HbEventBus;
+};
+
+export const getProjectWindowData = () => {
+  const prefix = voltranConfig.prefix.toUpperCase();
+  return process.env.BROWSER && window && window[prefix];
+};
 
 export function s4() {
   return Math.floor((1 + Math.random()) * 0x10000)


### PR DESCRIPTION
✅ Added Request Dispatcher layer
 - the request dispatcher is automatically added to the response created in all multiple requests.
 - If not used, `requestDispathcer=false` must be passed as a query.

🤖 Usage

1. creating a file where you keep your request configs.
2. the created file path as `requestConfigs` to the routing section under voltran config

```
routing: {
    components: path.resolve(__dirname, './src/appRoute/components.js'),
    dictionary: path.resolve(__dirname, './src/appRoute/dictionary.js'),
    requestConfigs: path.resolve(__dirname, './src/requestConfigs/effects.js')
  },
```

🐠 Example request config file

Here we have an effect called GetFacets. In the example, if ProductList is loaded in the Project, if there is no `requests.getProductsAndFacets` request, it means requests.getFacets request by default.

In the request section, we have controls. When the getProductsAndFacets request comes, which request will it throw and which pending effects will be sent. So in the example, when the `getProductsAndFacets` request is made, the incoming data will be sent to the components that listen to both `GetFacets` and `GetProduct` effects.
```
const effects = {
  GetFacets: {
    ProductList: requests.getProductsAndFacets
    default: requests.getFacets
  }
};

const requests = {
  getProductsAndFacets: {
    Request: getProductsAndFacets,
    Subscribers: ['GetFacets', 'GetProducts']
  },
  getFacets: {
    Request: getFacets,
    Subscribers: ['GetFacets']
  },
};


export default {
  effects
};

```



* /components/VerticalFilter,ProductList?preview
* /components/VerticalFilter,ProductList?preview&requestDispathcer=false `// request dispatcher won't load`