### PR TITLE
Add error message attribute on newrelic errors.

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -117,6 +117,7 @@ const cors = async (req, res, next) => {
 
 const utils = async (req, res, next) => {
   res.json = json => {
+    newrelic?.addCustomAttribute("voltran.error.message", JSON.stringify(json.message))
     res.setHeader('Content-Type', 'application/json; charset=utf-8');
     res.end(JSON.stringify(json));
   };

--- a/src/server.js
+++ b/src/server.js
@@ -117,7 +117,7 @@ const cors = async (req, res, next) => {
 
 const utils = async (req, res, next) => {
   res.json = json => {
-    newrelic?.addCustomAttribute("voltran.error.message", JSON.stringify(json.message))
+    addCustomAttrsToNewrelic(json.message)
     res.setHeader('Content-Type', 'application/json; charset=utf-8');
     res.end(JSON.stringify(json));
   };

--- a/src/universal/tools/newrelic/newrelic.js
+++ b/src/universal/tools/newrelic/newrelic.js
@@ -6,6 +6,30 @@ let newrelic = null;
 if (newrelicEnabled) {
   // eslint-disable-next-line global-require
   newrelic = require('newrelic');
+  console.log(" ---- NewRelic is ENABLED! ----")
+} else {
+  console.log(" ---- NewRelic is DISABLED! ----")
+}
+
+const isJsonValid = (str) => {
+  try {
+    JSON.parse(str);
+  } catch (e) {
+    return false;
+  }
+  return true;
+}
+
+export const addCustomAttrsToNewrelic = (message) => {
+  const isValidJson = isJsonValid(message)
+  if (!isValidJson) return;
+  const parsedMessage = JSON.parse(message)
+  for (const key in parsedMessage) {
+    if (Object.hasOwnProperty.call(parsedMessage, key)) {
+      newrelic?.addCustomAttribute(`a_${key}`, parsedMessage[key])
+    }
+  }
+  newrelic?.addCustomAttribute("a_voltran.error.message", message)
 }
 
 export default newrelic;


### PR DESCRIPTION
All of the server-side errors seem as `500 Error` on the error page. There is no further detailed information about especially error messages. Hence, I have added the error message (`@m`) as an attribute. You can see the related error message on the `Error` page on NewRelic One.

Furthermore, we can improve our new relic tool by adding properties that need for us while monitoring.