### PR TITLE
ci: add security scanning workflow (npm audit, Trivy, SBOM)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,84 @@
+name: Security
+
+on:
+  push:
+    branches: [master, main]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+  schedule:
+    # Run weekly on Monday 08:00 UTC to catch newly published CVEs
+    - cron: '0 8 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  npm-audit:
+    name: npm Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run npm audit
+        # Fail on HIGH and CRITICAL severity vulnerabilities
+        run: npm audit --audit-level=high
+
+  trivy-fs:
+    name: Trivy Filesystem Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Trivy (filesystem)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          trivy-config: .trivy.yaml
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+
+      - name: Upload Trivy SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate SBOM with Trivy
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: cyclonedx
+          output: sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cdx.json
+          retention-days: 90

--- a/.trivy.yaml
+++ b/.trivy.yaml
@@ -1,0 +1,12 @@
+scan:
+  skip-dirs:
+    - node_modules
+    - coverage
+    - dist
+    - .next
+
+vulnerability:
+  ignore-unfixed: false
+
+misconfiguration:
+  include-non-failures: false


### PR DESCRIPTION
## What

This PR introduces a dedicated `security.yml` GitHub Actions workflow that adds three security gates currently absent from the project.

## Why

The repository currently has no CI at all. Without automated dependency scanning, HIGH/CRITICAL CVEs in npm packages can silently reach production. This is a minimal, non-breaking addition that brings the project in line with supply-chain security best practices.

## Changes

**`.github/workflows/security.yml`** — three parallel jobs:

| Job | Tool | Purpose |
|---|---|---|
| `npm-audit` | `npm audit` | Fail on HIGH/CRITICAL severity npm dependency vulnerabilities |
| `trivy-fs` | Trivy 0.28 | Filesystem scan; results uploaded as SARIF to the GitHub Security tab |
| `sbom` | Trivy (CycloneDX) | Generate a Software Bill of Materials artifact retained for 90 days |

**`.trivy.yaml`** — Trivy config that skips `node_modules/`, `dist/`, and `coverage/` to keep results focused on source-level findings.

**Trigger schedule:** runs on every push/PR and weekly (Monday 08:00 UTC) so newly published CVEs are caught between releases.

## Test plan

- [ ] Workflow syntax validated locally
- [ ] `npm audit --audit-level=high` exits 0 on current lockfile
- [ ] Trivy scan completes without blocking HIGH/CRITICAL findings
- [ ] SBOM artifact is generated and downloadable from the Actions run